### PR TITLE
Remove 'pinned' => false from dfLastTopicInForum

### DIFF
--- a/Controller/PostController.php
+++ b/Controller/PostController.php
@@ -38,7 +38,6 @@ class PostController extends BasePostController
     public function postAction(Request $request, Topic $topic)
     {
         $preview = false;
-        
         $posts = $this->getPaginator()->pagignate('posts', $topic->getPosts());
 
         if (( $form = $this->generatePostForm($request, $topic) ) !== NULL) {
@@ -59,13 +58,13 @@ class PostController extends BasePostController
         }
         
         return $this->render('DForumBundle::post.html.twig', array(
-            'topic' => $topic,
+            'topic' => $this->incrementeView($topic),
             'posts' => $posts,
             'form'  => $form,
             'postpreview' => $preview
         ));
     }
-    
+
     /**
      * 
      * Delete a post and redirection in post page or topic page after delete.
@@ -143,4 +142,17 @@ class PostController extends BasePostController
 
     }
 
+    /**
+     * @param Topic $topic
+     * @return Topic
+     */
+    private function incrementeView(Topic $topic)
+    {
+        $topic->addView();
+        $em = $this->getEm();
+        $em->persist($topic);
+        $em->flush();
+
+        return $topic;
+    }
 }

--- a/Controller/TopicController.php
+++ b/Controller/TopicController.php
@@ -76,8 +76,8 @@ class TopicController extends BaseTopicController
         $em->remove($topic);
         $em->flush();
         $request->getSession()->getFlashBag()->add('success', $this->getTranslator()->trans('discutea.forum.topic.delete'));
-        return $this->redirect($this->generateUrl('discutea_forum_topic', array('slug' => $forumSlug)));       
- 
+
+        return $this->redirect($this->generateUrl('discutea_forum_topic', array('slug' => $forumSlug)));
     }
 
     /**

--- a/Entity/Model/BaseTopic.php
+++ b/Entity/Model/BaseTopic.php
@@ -85,7 +85,14 @@ abstract class BaseTopic
      * @ORM\Column(type="datetime", nullable=true)
      */
     protected $lastPost;
-    
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="integer")
+     */
+    protected $views = 0;
+
     /**
      * Constructor
      */
@@ -341,5 +348,41 @@ abstract class BaseTopic
     public function getLastPost()
     {
         return $this->lastPost;
+    }
+
+    /**
+     * Set views
+     *
+     * @param int $wiews
+     *
+     * @return Topic
+     */
+    public function setViews($views)
+    {
+        $this->views = $views;
+
+        return $this;
+    }
+
+    /**
+     * Get views
+     *
+     * @return integer
+     */
+    public function getViews()
+    {
+        return $this->views;
+    }
+
+    /**
+     * Add view
+     *
+     * @return Topic
+     */
+    public function addView()
+    {
+        $this->views = $this->views + 1;
+
+        return $this;
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Before setting up everything, this bundle requires that you install KnpPaginator
             // END OF DEPENDANCY
             new Discutea\DForumBundle\DForumBundle(),
             // ...
- ```
-
+```
+ 
 4: Add routes routes
  
  
@@ -124,7 +124,7 @@ Before setting up everything, this bundle requires that you install KnpPaginator
 
 All set, browse /forum and start by creating your first category and forum
  
-9: Avoid to 404
+8: Avoid to 404
    http://symfony.com/doc/current/cookbook/routing/redirect_trailing_slash.html
 
 ## MORE INFO

--- a/README_fr.md
+++ b/README_fr.md
@@ -58,15 +58,18 @@ Avant de commencer installer KnpPaginatorBundle si cela n'est pas déjà fait.
 
 4: Ajouter les routes
 
-```yml
+
     # app/Config/routing.yml
+
     discutea_forum:
         resource: "@DForumBundle/Resources/config/routing.yml"
         prefix:   /
-```
+
 5: Ajouter la configuration du bundle:
-```yml
+
 # Configuration de l'entité utilisateur
+
+
     doctrine:
         orm:
             auto_generate_proxy_classes: "%kernel.debug%"
@@ -74,7 +77,6 @@ Avant de commencer installer KnpPaginatorBundle si cela n'est pas déjà fait.
             auto_mapping: true
             resolve_target_entities:
                 Symfony\Component\Security\Core\User\UserInterface: Namespace\YourUserBundle\Entity\User
-
 
     # Stof Doctrine Extensions
     stof_doctrine_extensions:
@@ -106,7 +108,6 @@ Avant de commencer installer KnpPaginatorBundle si cela n'est pas déjà fait.
             posts:
                 enabled: true
                 per_page: 10
-```
 
 6: Ajouter un ROLE_MODERATOR dans app/config/security.yml
 
@@ -127,8 +128,6 @@ C'est prêt, rendez-vous à l'adresse /forum et créez votre première categorie
 
 ##  INFORMATIONS PRATIQUES
 
-8: Eviter les 404
-    http://symfony.com/doc/current/cookbook/routing/redirect_trailing_slash.html  
 
 Pour une aide ou demander des fonctionalités merci de me joindre sur IRC (Anglais ou Français)
   - serveur: irc.ircz.fr:6667

--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -153,6 +153,14 @@
                 <source>discutea.forum.topic.title</source>
                 <target>Title of the topic:</target>
             </trans-unit>
+            <trans-unit id="t7">
+                <source>discutea.forum.topic.view</source>
+                <target>view</target>
+            </trans-unit>
+            <trans-unit id="t8">
+                <source>discutea.forum.topic.views</source>
+                <target>views</target>
+            </trans-unit>
             <!-- Posts -->
             <trans-unit id="p1">
                 <source>discutea.forum.warning.preview</source>

--- a/Resources/translations/messages.es.xlf
+++ b/Resources/translations/messages.es.xlf
@@ -153,6 +153,14 @@
                 <source>discutea.forum.topic.title</source>
                 <target>Título del asunto :</target>
             </trans-unit>
+            <trans-unit id="t7">
+                <source>discutea.forum.topic.view</source>
+                <target>vista</target>
+            </trans-unit>
+            <trans-unit id="t8">
+                <source>discutea.forum.topic.views</source>
+                <target>vistas</target>
+            </trans-unit>
             <!-- Posts -->
             <trans-unit id="p1">
                 <source>discutea.forum.warning.preview</source>

--- a/Resources/translations/messages.fi.xlf
+++ b/Resources/translations/messages.fi.xlf
@@ -153,6 +153,14 @@
                 <source>discutea.forum.topic.title</source>
                 <target>Aiheen otsikko:</target>
             </trans-unit>
+            <trans-unit id="t7">
+                <source>discutea.forum.topic.view</source>
+                <target>näkymät</target>
+            </trans-unit>
+            <trans-unit id="t8">
+                <source>discutea.forum.topic.views</source>
+                <target>näkymät</target>
+            </trans-unit>
             <!-- Posts -->
             <trans-unit id="p1">
                 <source>discutea.forum.warning.preview</source>

--- a/Resources/translations/messages.fr.xlf
+++ b/Resources/translations/messages.fr.xlf
@@ -153,6 +153,14 @@
                 <source>discutea.forum.topic.title</source>
                 <target>Titre du sujet :</target>
             </trans-unit>
+            <trans-unit id="t7">
+                <source>discutea.forum.topic.view</source>
+                <target>vue</target>
+            </trans-unit>
+            <trans-unit id="t8">
+                <source>discutea.forum.topic.views</source>
+                <target>vues</target>
+            </trans-unit>
             <!-- Posts -->
             <trans-unit id="p1">
                 <source>discutea.forum.warning.preview</source>

--- a/Resources/views/topic.html.twig
+++ b/Resources/views/topic.html.twig
@@ -24,7 +24,8 @@
             </div>
             <div class="col-md-2 topic-msg-count">
               {% set posts_count = topic.posts|length %}
-              <p><span class="badge">{{ posts_count }} {% if posts_count > 1 %}{{ 'discutea.forum.posts'|trans }}{% else %}{{ 'discutea.forum.post'|trans }}{% endif %}</span></p>
+              <p><span class="badge">{{ posts_count }} {{ posts_count > 1 ? 'discutea.forum.posts'|trans : 'discutea.forum.post'|trans }}</span></p>
+              <p><span class="badge">{{ topic.views }} {{ topic.views > 1 ? 'discutea.forum.topic.views'|trans : 'discutea.forum.topic.view'|trans }}</span></p>
               <p>
                 {% if topic.resolved == true %}<br />{{ 'discutea.forum.label.issolved'|trans }}{% endif %}
                 {% if topic.pinned == true %}<br />{{ 'discutea.forum.label.ispinned'|trans }}{% endif %}

--- a/Twig/DForumExtension.php
+++ b/Twig/DForumExtension.php
@@ -2,6 +2,7 @@
 
 namespace Discutea\DForumBundle\Twig;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\UserInterface as Poster;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Discutea\DForumBundle\Entity\Forum;
@@ -17,7 +18,7 @@ class DForumExtension extends \Twig_Extension
 
     /**
      *
-     * @var object Symfony\Bundle\FrameworkBundle\Routing\Router
+     * @var UrlGeneratorInterface
      */
     private $router;
 
@@ -26,7 +27,8 @@ class DForumExtension extends \Twig_Extension
      */
     private $config;
 
-    public function __construct (ObjectManager $objectManager, Router $router, $paginationConfig) {
+    public function __construct (ObjectManager $objectManager, UrlGeneratorInterface $router, $paginationConfig)
+    {
         $this->em = $objectManager;
         $this->router = $router;
         $this->config = $paginationConfig;

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/orm": "^2.5",
         "sensio/distribution-bundle": "^5.0",
         "symfony/swiftmailer-bundle": "^2.4",
-        "sensio/framework-extra-bundle": "^3.0.2",
+        "sensio/framework-extra-bundle": "^3.0.2 || ^5.0.0",
         "stof/doctrine-extensions-bundle": ">=1.2",
         "knplabs/knp-paginator-bundle": ">=2.5"
     },


### PR DESCRIPTION
This function cause crashes when you answer to a pinned post (idk if it's the same for everyone)
`Impossible to access an attribute ("poster") on a boolean variable ("").`

So I have changed 
``` php
public function dfLastTopicInForum(Forum $forum)
    {
        $topic = $this->em->getRepository('DForumBundle:Topic')->findOneBy(
            array('forum' => $forum, 'pinned' => false),
            array('lastPost' => 'DESC'));
        return $topic;
    }
```
To 
``` php
public function dfLastTopicInForum(Forum $forum)
    {
        $topic = $this->em->getRepository('DForumBundle:Topic')->findOneBy(
            array('forum' => $forum),
            array('lastPost' => 'DESC'));
        return $topic;
    }
```

And now it's work fine.